### PR TITLE
メニュークリックでモーダルを閉じる / レイアウトの余白調整

### DIFF
--- a/app/components/layout/header-parts/HamburgerMenu.tsx
+++ b/app/components/layout/header-parts/HamburgerMenu.tsx
@@ -31,8 +31,12 @@ const HamburgerMenu = () => {
           onClick={handleBackdropClick}
           className="fixed inset-0 bg-black bg-opacity-60 backdrop-blur-sm z-50"
         >
-          <div className="flex flex-col w-48 h-full ml-auto rounded-l-2xl  bg-white">
-            <HeaderMenu ulClass="pt-20" liClass="text-lg font-semibold" />
+          <div className="flex flex-col w-48 h-full ml-auto rounded-l-2xl bg-white">
+            <HeaderMenu
+              ulClass="pt-20"
+              liClass="text-lg font-semibold"
+              closeMenu={closeMenu}
+            />
             <Button
               type="button"
               color="white"

--- a/app/components/layout/header-parts/HeaderMenu.tsx
+++ b/app/components/layout/header-parts/HeaderMenu.tsx
@@ -3,9 +3,14 @@
 type HeaderMenuProps = {
   liClass?: string;
   ulClass?: string;
+  closeMenu?: () => void;
 };
 
-const HeaderMenu: React.FC<HeaderMenuProps> = ({ liClass, ulClass }) => {
+const HeaderMenu: React.FC<HeaderMenuProps> = ({
+  liClass,
+  ulClass,
+  closeMenu,
+}) => {
   const scrollToSection = (id: string) => {
     const el = document.getElementById(id);
     if (el) {
@@ -13,6 +18,13 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({ liClass, ulClass }) => {
         behavior: "smooth",
         block: "start",
       });
+    }
+  };
+
+  const handleClick = (id: string) => {
+    scrollToSection(id);
+    if (closeMenu) {
+      closeMenu();
     }
   };
 
@@ -30,7 +42,7 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({ liClass, ulClass }) => {
           <li
             key={item.id}
             className={`${liClass} p-4 hover:bg-sky-400 hover:text-white cursor-pointer`}
-            onClick={() => scrollToSection(item.id)}
+            onClick={() => handleClick(item.id)}
           >
             <span>{item.name}</span>
           </li>

--- a/app/components/section/About.tsx
+++ b/app/components/section/About.tsx
@@ -21,7 +21,7 @@ const About = () => {
         <AnimatedItem
           elementType="div"
           animation="fadeInDown"
-          className="w-full px-4 sm:flex-1 order-2 sm:order-1"
+          className="w-full px-2 sm:flex-1 order-2 sm:order-1"
         >
           {texts.map((text, index) => (
             <p key={index}>{text}</p>

--- a/app/components/section/Profile.tsx
+++ b/app/components/section/Profile.tsx
@@ -45,13 +45,13 @@ const Profile = () => {
 
   return (
     <Section id="profile" title="プロフィール">
-      <div className="border-l-8 ml-10 border-gray-700">
-        <ul className="mx-6">
+      <div className="border-l-8 ml-2 md:ml-10 border-gray-700">
+        <ul className="ml-6 mr-2">
           {ProfileLists.map((ProfileList) => (
             <AnimatedItem
               animation="fadeInRight"
               elementType="li"
-              className="relative my-20 p-4 border border-gray-300 bg-gradient-to-br from-indigo-50 to-sky-100 break-words"
+              className="relative my-10 md:my-20 p-4 border border-gray-300 bg-gradient-to-br from-zinc-50 to-sky-100 break-words"
               key={ProfileList.id}
             >
               <Image

--- a/app/components/ui/AnimatedItem.tsx
+++ b/app/components/ui/AnimatedItem.tsx
@@ -97,7 +97,7 @@ const AnimatedItem: React.FC<AnimatedItemProps> = ({
       opacity: 1,
       transition: {
         delay: delay || 0,
-        duration: 0.6,
+        duration: 1.2,
       },
     },
   };

--- a/app/components/ui/BackToTopButton.tsx
+++ b/app/components/ui/BackToTopButton.tsx
@@ -31,7 +31,7 @@ const BackToTopButton = () => {
   return (
     <>
       {isVisible && (
-        <button onClick={backToTop} type="button" className="fixed bottom-14 right-4 py-2 px-4 font-bold rounded-full opacity-80 text-white bg-blue-500 hover:bg-blue-700 transition-colors duration-300 z-10">
+        <button onClick={backToTop} type="button" className="fixed bottom-4 md:bottom-10 right-4 py-2 px-4 font-bold rounded-full text-white bg-blue-400 hover:bg-blue-700 transition-colors duration-300 z-10">
           トップへ戻る
         </button>
       )}

--- a/app/components/work/AppContainer.tsx
+++ b/app/components/work/AppContainer.tsx
@@ -8,7 +8,7 @@ const AppContainer: React.FC<AppContainerProps> = ({
   bg = "bg-white"
 }) => {
   return (
-    <div className={`w-full py-8 ${bg}`}>
+    <div className={`w-full py-12 ${bg}`}>
       <div className="w-full max-w-[1050px] mx-auto px-2">
         {children}
       </div>

--- a/app/components/work/AppContainer.tsx
+++ b/app/components/work/AppContainer.tsx
@@ -1,17 +1,17 @@
 type AppContainerProps = {
   children: React.ReactNode;
-  border?: boolean;
+  bg?: string;
 };
 
 const AppContainer: React.FC<AppContainerProps> = ({
   children,
-  border = true,
+  bg = "bg-white"
 }) => {
-  const borderBottom = border ? "border-b border-dashed border-gray-700" : "";
-
   return (
-    <div className={`w-full max-w-[1050px] mx-auto px-2 my-6 pb-14 ${borderBottom}`}>
-      {children}
+    <div className={`w-full py-8 ${bg}`}>
+      <div className="w-full max-w-[1050px] mx-auto px-2">
+        {children}
+      </div>
     </div>
   );
 };

--- a/app/components/work/AppDetail.tsx
+++ b/app/components/work/AppDetail.tsx
@@ -30,7 +30,7 @@ const AppDetail: React.FC<AppDetailProps> = ({
       <AnimatedItem
         elementType="div"
         animation={animation}
-        className="mx-auto py-4 my-10"
+        className="mx-auto"
       >
         <h3 className="block w-full text-3xl text-center font-bold mb-10 leading-relaxed">
           {title}

--- a/app/components/work/Work.tsx
+++ b/app/components/work/Work.tsx
@@ -15,7 +15,7 @@ const Work = () => {
 
   return (
     <WorkSection id="works" title="Works">
-      <div className="text-center break-words">
+      <div className="text-center break-words mb-12">
         {contents.map((content, index) => (
           <p key={index} className="text-center">
             {content}

--- a/app/components/work/Work.tsx
+++ b/app/components/work/Work.tsx
@@ -4,6 +4,7 @@ import Blog from "./apps/Blog";
 import LaravelPractice from "./apps/LaravelPractice";
 import LaravelAcademy from "./apps/LaravelAcademy";
 import WorkSection from "./WorkSection";
+import AnimatedItem from "../ui/AnimatedItem";
 
 const Work = () => {
   const contents = [
@@ -15,13 +16,17 @@ const Work = () => {
 
   return (
     <WorkSection id="works" title="Works">
-      <div className="text-center break-words mb-12">
+      <AnimatedItem
+        elementType="div"
+        animation="fadeInOpacity"
+        className="text-center break-words mb-12"
+      >
         {contents.map((content, index) => (
           <p key={index} className="text-center">
             {content}
           </p>
         ))}
-      </div>
+      </AnimatedItem>
       <MemoryBook />
       <MemoBooksNote />
       <LaravelAcademy />

--- a/app/components/work/Work.tsx
+++ b/app/components/work/Work.tsx
@@ -1,9 +1,9 @@
-import Section from "../section/Section";
 import MemoryBook from "./apps/MemoryBook";
 import MemoBooksNote from "./apps/MemoBooksNote";
 import Blog from "./apps/Blog";
 import LaravelPractice from "./apps/LaravelPractice";
 import LaravelAcademy from "./apps/LaravelAcademy";
+import WorkSection from "./WorkSection";
 
 const Work = () => {
   const contents = [
@@ -14,7 +14,7 @@ const Work = () => {
   ];
 
   return (
-    <Section id="works" title="Works">
+    <WorkSection id="works" title="Works">
       <div className="text-center break-words">
         {contents.map((content, index) => (
           <p key={index} className="text-center">
@@ -27,7 +27,7 @@ const Work = () => {
       <LaravelAcademy />
       <Blog />
       <LaravelPractice />
-    </Section>
+    </WorkSection>
   );
 };
 

--- a/app/components/work/WorkSection.tsx
+++ b/app/components/work/WorkSection.tsx
@@ -1,0 +1,32 @@
+import AnimatedItem from "../ui/AnimatedItem";
+
+type WorkSectionProps = {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+};
+
+const WorkSection: React.FC<WorkSectionProps> = ({
+  id,
+  title,
+  children,
+}) => {
+
+  return (
+    <section
+      id={id}
+      className="w-full pt-10 overflow-x-hidden bg-white"
+    >
+      <AnimatedItem
+        animation="fadeInOpacity"
+        elementType="h2"
+        className="w-full text-3xl text-center font-bold mb-10 leading-relaxed"
+      >
+        {title}
+      </AnimatedItem>
+      {children}
+    </section>
+  );
+};
+
+export default WorkSection;

--- a/app/components/work/apps/Blog.tsx
+++ b/app/components/work/apps/Blog.tsx
@@ -164,7 +164,7 @@ const Blog = () => {
         elementType="div"
         className="text-center"
       >
-        <h3 className="w-full my-10 text-3xl font-bold leading-relaxed">
+        <h3 className="w-full mb-10 text-3xl font-bold leading-relaxed">
           Next.js製のブログ作成アプリ
         </h3>
         <p>「作成したアプリの集客用」「個人での利用」</p>

--- a/app/components/work/apps/LaravelAcademy.tsx
+++ b/app/components/work/apps/LaravelAcademy.tsx
@@ -4,7 +4,7 @@ import Modal from "../../ui/Modal";
 
 const LaravelAcademy = () => {
   return (
-    <AppContainer>
+    <AppContainer bg="bg-zinc-50">
       <AppDetail
         title="「レッスンアカデミー」- 4択/フラッシュカード 学習アプリ -"
         contents={[

--- a/app/components/work/apps/LaravelPractice.tsx
+++ b/app/components/work/apps/LaravelPractice.tsx
@@ -72,7 +72,7 @@ const LaravelPractice = () => {
         {
           image: "/image_webp/laravel-livewire-form.webp",
           text: "フォームバリデーション",
-        }
+        },
       ],
       explanations: {
         overview:
@@ -91,13 +91,13 @@ const LaravelPractice = () => {
   ];
 
   return (
-    <AppContainer border={false}>
+    <AppContainer bg="bg-zinc-50">
       <AnimatedItem
         animation="fadeInOpacity"
         elementType="div"
         className="text-center"
       >
-        <h3 className="w-full my-10 text-3xl font-bold leading-relaxed">
+        <h3 className="w-full mb-10 text-3xl font-bold leading-relaxed">
           Laravelの学習目的に作成した旅程表アプリ
         </h3>
         <p>Laravelを学習して知識の定着の為に、学習目的に制作したアプリです。</p>

--- a/app/components/work/apps/MemoryBook.tsx
+++ b/app/components/work/apps/MemoryBook.tsx
@@ -4,7 +4,7 @@ import Modal from "../../ui/Modal";
 
 const MemoryBook = () => {
   return (
-    <AppContainer>
+    <AppContainer bg="bg-zinc-50">
       <AppDetail
         title="「旅のメモリーブック」旅程表作成アプリ"
         contents={[


### PR DESCRIPTION
## メニューをクリックでモーダルを閉じる

- ハンバーガーメニューをクリック時にモーダルも閉じるよう変更

今まではハンバーガーメニュー内の各アイテムをクリックしても、スクロールだけでモーダルは閉じないようにしていた。
なんとなく各セクションに何が書かれているか分かるようにしていた。

しかし、ブラーを聞かせたりデザインを変更したことによって、スクロールをしても内容が見えなくなった。
そのため、アイテムをクリックしたらモーダルも閉じるように変更。

## レイアウトの余白調整
- topへ戻るボタンを画面サイズで変更
- Worlセクションのレイアウト変更
- 各workに背景色の設定と余白調整
- プロフィールエリアの余白調整
- workセクションにアニメーションの追加

